### PR TITLE
Add Transform state tracking with notifier

### DIFF
--- a/Assets/Main/Modules/GUISystem/ITransformChangeHandler.cs
+++ b/Assets/Main/Modules/GUISystem/ITransformChangeHandler.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+namespace GUISystem
+{
+    /// <summary>
+    /// Transformの変化を受け取るインターフェースです。
+    /// </summary>
+    public interface ITransformChangeHandler
+    {
+        /// <summary>
+        /// Transformが変化した際に呼び出されます。
+        /// </summary>
+        /// <param name="changed">変化したTransform</param>
+        void OnTransformChanged(Transform changed);
+    }
+}

--- a/Assets/Main/Modules/GUISystem/ITransformChangeHandler.cs.meta
+++ b/Assets/Main/Modules/GUISystem/ITransformChangeHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0ad1146680dd4b42bb53751193df6cc2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Main/Modules/GUISystem/Tests/GUISystem.Tests.asmdef
+++ b/Assets/Main/Modules/GUISystem/Tests/GUISystem.Tests.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "GUISystem.Tests",
+    "references": [
+        "GUISystem"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Main/Modules/GUISystem/Tests/GUISystem.Tests.asmdef.meta
+++ b/Assets/Main/Modules/GUISystem/Tests/GUISystem.Tests.asmdef.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 808151640db04931a3756474f15f0d06
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Main/Modules/GUISystem/Tests/TransformStateTests.cs
+++ b/Assets/Main/Modules/GUISystem/Tests/TransformStateTests.cs
@@ -1,0 +1,32 @@
+using NUnit.Framework;
+using UnityEngine;
+
+namespace GUISystem.Tests
+{
+    /// <summary>
+    /// TransformStateの挙動を検証するテストです。
+    /// </summary>
+    public class TransformStateTests
+    {
+        [Test]
+        public void DetectsPositionChange()
+        {
+            GameObject go = new GameObject("test");
+            TransformState state = new TransformState(go.transform);
+            go.transform.localPosition = new Vector3(1f, 0f, 0f);
+            Assert.IsTrue(state.HasChanged(go.transform));
+            Object.DestroyImmediate(go);
+        }
+
+        [Test]
+        public void CaptureUpdatesValues()
+        {
+            GameObject go = new GameObject("test");
+            TransformState state = new TransformState(go.transform);
+            go.transform.localPosition = new Vector3(1f, 0f, 0f);
+            state.Capture(go.transform);
+            Assert.IsFalse(state.HasChanged(go.transform));
+            Object.DestroyImmediate(go);
+        }
+    }
+}

--- a/Assets/Main/Modules/GUISystem/Tests/TransformStateTests.cs.meta
+++ b/Assets/Main/Modules/GUISystem/Tests/TransformStateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ffa0fe68a234ab1943a2afe70e1ed26
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Main/Modules/GUISystem/TransformChangeNotifier.cs
+++ b/Assets/Main/Modules/GUISystem/TransformChangeNotifier.cs
@@ -1,0 +1,109 @@
+using System;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace GUISystem
+{
+    /// <summary>
+    /// Transformの変化を検知しイベントを発行するコンポーネントです。
+    /// </summary>
+    [ExecuteAlways]
+    public class TransformChangeNotifier : MonoBehaviour
+    {
+        /// <summary>
+        /// 変化時に通知されるイベントです。
+        /// </summary>
+        public TransformUnityEvent OnTransformChanged => _onTransformChanged;
+
+        [SerializeField]
+        private TransformUnityEvent _onTransformChanged = new();
+
+        private TransformState _state;
+        private bool _hierarchyDirty;
+
+        void Awake()
+        {
+            _state = new TransformState(transform);
+        }
+
+        void OnTransformParentChanged()
+        {
+            MarkDirty();
+        }
+
+        void OnTransformChildrenChanged()
+        {
+            MarkDirty();
+        }
+
+#if UNITY_EDITOR
+        void OnEnable()
+        {
+            EditorApplication.hierarchyChanged += MarkDirty;
+        }
+
+        void OnDisable()
+        {
+            EditorApplication.hierarchyChanged -= MarkDirty;
+        }
+#endif
+
+        void LateUpdate()
+        {
+            if (_state.HasChanged(transform))
+            {
+                _state.Capture(transform);
+                _onTransformChanged.Invoke(transform);
+            }
+
+            if (_hierarchyDirty)
+            {
+                _hierarchyDirty = false;
+                _state.Capture(transform);
+                _onTransformChanged.Invoke(transform);
+            }
+        }
+
+        /// <summary>
+        /// 変化通知を強制的に送信します。
+        /// </summary>
+        public void ForceNotify()
+        {
+            _state.Capture(transform);
+            _onTransformChanged.Invoke(transform);
+        }
+
+        /// <summary>
+        /// リスナーを登録します。
+        /// </summary>
+        /// <param name="handler">ハンドラー</param>
+        public void RegisterHandler(ITransformChangeHandler handler)
+        {
+            _onTransformChanged.AddListener(handler.OnTransformChanged);
+        }
+
+        /// <summary>
+        /// リスナーを解除します。
+        /// </summary>
+        /// <param name="handler">ハンドラー</param>
+        public void UnregisterHandler(ITransformChangeHandler handler)
+        {
+            _onTransformChanged.RemoveListener(handler.OnTransformChanged);
+        }
+
+        void MarkDirty()
+        {
+            _hierarchyDirty = true;
+        }
+    }
+
+    /// <summary>
+    /// Transformを引数とするUnityEventです。
+    /// </summary>
+    [Serializable]
+    public class TransformUnityEvent : UnityEvent<Transform>
+    {
+    }
+}

--- a/Assets/Main/Modules/GUISystem/TransformChangeNotifier.cs.meta
+++ b/Assets/Main/Modules/GUISystem/TransformChangeNotifier.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5edab546f20d4d03acd30973de91501b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Main/Modules/GUISystem/TransformState.cs
+++ b/Assets/Main/Modules/GUISystem/TransformState.cs
@@ -1,0 +1,58 @@
+using UnityEngine;
+
+namespace GUISystem
+{
+    /// <summary>
+    /// Transformの状態を保持し変化検知を行うクラスです。
+    /// </summary>
+    [System.Serializable]
+    public class TransformState
+    {
+        /// <summary>
+        /// ローカル位置
+        /// </summary>
+        public Vector3 LocalPosition { get; private set; }
+
+        /// <summary>
+        /// ローカル回転
+        /// </summary>
+        public Quaternion LocalRotation { get; private set; }
+
+        /// <summary>
+        /// ローカルスケール
+        /// </summary>
+        public Vector3 LocalScale { get; private set; }
+
+        /// <summary>
+        /// 新しいインスタンスを生成します。
+        /// </summary>
+        /// <param name="target">監視対象のTransform</param>
+        public TransformState(Transform target)
+        {
+            Capture(target);
+        }
+
+        /// <summary>
+        /// 変化があるかどうか確認します。
+        /// </summary>
+        /// <param name="target">比較対象のTransform</param>
+        /// <returns>変化があればtrue</returns>
+        public bool HasChanged(Transform target)
+        {
+            return LocalPosition != target.localPosition ||
+                   LocalRotation != target.localRotation ||
+                   LocalScale != target.localScale;
+        }
+
+        /// <summary>
+        /// 現在の状態を保存します。
+        /// </summary>
+        /// <param name="target">コピー元となるTransform</param>
+        public void Capture(Transform target)
+        {
+            LocalPosition = target.localPosition;
+            LocalRotation = target.localRotation;
+            LocalScale = target.localScale;
+        }
+    }
+}

--- a/Assets/Main/Modules/GUISystem/TransformState.cs.meta
+++ b/Assets/Main/Modules/GUISystem/TransformState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 37d09bec7db54a048df891c65de27c7b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- refactor `TransformChangeNotifier` to use a serializable `TransformState`
- add `ITransformChangeHandler` interface
- expose `TransformUnityEvent` for callbacks
- include unit tests for `TransformState`

## Testing
- `dotnet test` *(fails: command not found)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851a15b709c832293d5c4cda6c2fe86